### PR TITLE
Clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,33 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y wget libterm-readline-perl-perl gcc libuv1-dev git nano
+ENV CCL_VERSION 1.11
+ENV DEBIAN_FRONTEND noninteractive
+
+ADD https://download.rethinkdb.com/apt/pubkey.gpg /tmp/rethinkdb-pubkey.gpg
+
+RUN echo "deb http://download.rethinkdb.com/apt xenial main" | tee /etc/apt/sources.list.d/rethinkdb.list && \
+	apt-key add - < /tmp/rethinkdb-pubkey.gpg && \
+	apt-get update && \
+	apt-get upgrade -y && \
+	apt-get install -y wget libterm-readline-perl-perl gcc libuv1-dev git \
+						rethinkdb && \
+	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ccl
-RUN wget -P /opt/ ftp://ftp.clozure.com/pub/release/1.11/ccl-1.11-linuxx86.tar.gz && mkdir -p /opt/ccl && tar xvzf /opt/ccl-1.11-linuxx86.tar.gz -C /opt/ccl --strip-components=1
+RUN wget -P /opt/ ftp://ftp.clozure.com/pub/release/${CCL_VERSION}/ccl-${CCL_VERSION}-linuxx86.tar.gz && \
+	mkdir -p /opt/ccl && \
+	tar xvzf /opt/ccl-${CCL_VERSION}-linuxx86.tar.gz -C /opt/ccl --strip-components=1
 
 # install quicklisp
 COPY quicklisp_install /quicklisp_install
 RUN wget https://beta.quicklisp.org/quicklisp.lisp
 RUN cat /quicklisp_install | /opt/ccl/lx86cl64 --load /quicklisp.lisp
 
-# install RethinkDB
-RUN echo "deb http://download.rethinkdb.com/apt xenial main" | tee /etc/apt/sources.list.d/rethinkdb.list && wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | apt-key add - && apt-get update && apt-get install rethinkdb -y
-
 # install turtl API
-RUN cd /opt/ && git clone https://github.com/turtl/api.git --depth 1
-RUN cd /root/quicklisp/local-projects && git clone git://github.com/orthecreedence/cl-hash-util
+RUN cd /opt/ && \
+	git clone https://github.com/turtl/api.git --depth 1
+RUN cd /root/quicklisp/local-projects && \
+	git clone git://github.com/orthecreedence/cl-hash-util
 RUN /opt/ccl/lx86cl64 -l /root/quicklisp/setup.lisp
 
 # config
@@ -26,8 +38,6 @@ RUN chmod a+x /opt/turtl-setup
 RUN chmod a+x /opt/turtl-start
 COPY launch.lisp /opt/api/
 COPY rethinkdb.conf /etc/rethinkdb/instances.d/instance1.conf
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # general settings
 EXPOSE 8181


### PR DESCRIPTION
- Perform all `apt` operations in one step
  - Due to how Docker layers work, it is best to perform all our
    operations within a single run (including cleanup) so we can
    save on image size
- Make the version for CCL a variable that makes it much easier to
  update to use a new version, saving lots of find-and-replace
- Increase readability by breaking chained commands onto multiple lines